### PR TITLE
修改设备锁实现

### DIFF
--- a/mirai-core/src/jvmMain/kotlin/net/mamoe/mirai/utils/HyperLinkLabel.kt
+++ b/mirai-core/src/jvmMain/kotlin/net/mamoe/mirai/utils/HyperLinkLabel.kt
@@ -1,0 +1,26 @@
+package net.mamoe.mirai.utils
+
+import java.awt.Desktop
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.net.URI
+import javax.swing.JLabel
+
+/**
+ * 构造方法中url指代用户需要点击的链接, text为显示的提示内容
+ */
+internal class HyperLinkLabel constructor(url: String, text: String) : JLabel() {
+    init {
+        super.setText("<html><a href='$url'>$text</a></html>");
+        addMouseListener(object : MouseAdapter() {
+
+            override fun mouseClicked(e: MouseEvent) {
+                try {
+                    Desktop.getDesktop().browse(URI(url))
+                } catch (ex: Exception) {
+                    ex.printStackTrace()
+                }
+            }
+        })
+    }
+}

--- a/mirai-core/src/jvmMain/kotlin/net/mamoe/mirai/utils/LoginSolver.swing.jvm.kt
+++ b/mirai-core/src/jvmMain/kotlin/net/mamoe/mirai/utils/LoginSolver.swing.jvm.kt
@@ -38,18 +38,14 @@ object SwingSolver : LoginSolver() {
 
     override suspend fun onSolveUnsafeDeviceLoginVerify(bot: Bot, url: String): String? {
         return openWindow("Mirai UnsafeDeviceLoginVerify(${bot.id})") {
-            JLabel(
-                """
+            JLabel("""
                 <html>
                 需要进行账户安全认证<br>
                 该账户有[设备锁]/[不常用登录地点]/[不常用设备登录]的问题<br>
                 完成以下账号认证即可成功登录|理论本认证在mirai每个账户中最多出现1次<br>
-                请将该链接在QQ浏览器中打开并完成认证<br>
-                成功后请关闭该窗口<br>
-                这步操作将在后续的版本中优化
-                """.trimIndent()
-            ).last()
-            JTextField(url).append()
+                成功后请关闭该窗口
+            """.trimIndent()).append()
+            HyperLinkLabel(url, "设备锁验证").last()
         }
     }
 }


### PR DESCRIPTION
原有的手动复制链接再粘贴到浏览器中, 操作比较复杂, 修改成可以点击超链接，自动弹出浏览器访问认证页面。
这一操作有助于扫码认证更加便捷